### PR TITLE
add missing fieldinfo check

### DIFF
--- a/core/src/main/java/io/smallrye/asyncapi/core/runtime/scanner/dataobject/TypeResolver.java
+++ b/core/src/main/java/io/smallrye/asyncapi/core/runtime/scanner/dataobject/TypeResolver.java
@@ -375,7 +375,7 @@ public class TypeResolver {
     }
 
     private static boolean acceptField(FieldInfo field) {
-        return !Modifier.isStatic(field.flags());
+        return !Modifier.isStatic(field.flags()) && !field.isSynthetic();
     }
 
     /**


### PR DESCRIPTION
fixed a bug, where a inner class annotated with @Schema had the outer class as a SchemaProperty