### PR TITLE
Add JMS (quarkus-prices) example

### DIFF
--- a/examples/jms/README.md
+++ b/examples/jms/README.md
@@ -1,0 +1,27 @@
+# Quarkus Artemis JMS
+
+This project illustrates how you can use Artemis JMS with Quarkus.
+
+## Artemis server
+
+First you need an JMS broker. You can follow the instructions from the [Apache Artemis web site](https://activemq.apache.org/components/artemis/) or run `docker-compose up` if you have docker installed on your machine.
+
+## Start the application
+
+The application can be started using:
+
+```bash
+mvn quarkus:dev
+```
+
+Then, open your browser to `http://localhost:8080/prices.html`, and you should see a button to fetch the last price.
+
+## Anatomy
+
+In addition to the `prices.html` page, the application is composed by 3 components:
+
+* `PriceProducer` - the `PriceProducer` sends random prices to a JMS queue.
+* `PriceConsumer` - the `PriceConsumer` receives the JMS message and stores the last price.
+* `PriceResource`  - the `PriceResource` is able to sent the last price of the PriceConsumer back to the browser.
+
+The configuration is located in the application configuration.

--- a/examples/jms/docker-compose.yaml
+++ b/examples/jms/docker-compose.yaml
@@ -1,0 +1,13 @@
+version: '2'
+
+services:
+
+  artemis:
+    image: vromero/activemq-artemis:2.9.0-alpine
+    ports:
+      - "8161:8161"
+      - "61616:61616"
+      - "5672:5672"
+    environment:
+      ARTEMIS_USERNAME: quarkus
+      ARTEMIS_PASSWORD: quarkus

--- a/examples/jms/pom.xml
+++ b/examples/jms/pom.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>io.smallrye</groupId>
+    <artifactId>smallrye-async-api-examples-jms</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <name>SmallRye: MicroProfile AsyncAPI Examples JMS</name>
+
+    <properties>
+        <version.quarkus>1.12.0.Final</version.quarkus>
+        <version.asyncapi>1.0.0-SNAPSHOT</version.asyncapi>
+
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>1.8</maven.compiler.source>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-universe-bom</artifactId>
+                <version>${version.quarkus}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-artemis-jms</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy</artifactId>
+        </dependency>
+
+        <!-- AsyncAPI -->
+        <dependency>
+            <groupId>io.smallrye</groupId>
+            <artifactId>smallrye-async-api-spec-api</artifactId>
+            <version>${version.asyncapi}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.smallrye</groupId>
+            <artifactId>smallrye-async-api-quarkus-extension</artifactId>
+            <version>${version.asyncapi}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-maven-plugin</artifactId>
+                <version>${version.quarkus}</version>
+                <configuration>
+                    <uberJar>true</uberJar>
+                    <ignoredEntries>
+                        <ignoredEntry>META-INF/DEPENDENCIES.txt</ignoredEntry>
+                    </ignoredEntries>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>build</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/examples/jms/src/main/docker/Dockerfile.jvm
+++ b/examples/jms/src/main/docker/Dockerfile.jvm
@@ -1,0 +1,31 @@
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.1
+
+ARG JAVA_PACKAGE=java-1.8.0-openjdk-headless
+ARG RUN_JAVA_VERSION=1.3.5
+
+ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
+
+# Install java and the run-java script
+# Also set up permissions for user `1001`
+RUN microdnf install openssl curl ca-certificates ${JAVA_PACKAGE} \
+    && microdnf update \
+    && microdnf clean all \
+    && mkdir /deployments \
+    && chown 1001 /deployments \
+    && chmod "g+rwX" /deployments \
+    && chown 1001:root /deployments \
+    && curl https://repo1.maven.org/maven2/io/fabric8/run-java-sh/${RUN_JAVA_VERSION}/run-java-sh-${RUN_JAVA_VERSION}-sh.sh -o /deployments/run-java.sh \
+    && chown 1001 /deployments/run-java.sh \
+    && chmod 540 /deployments/run-java.sh \
+    && echo "securerandom.source=file:/dev/urandom" >> /etc/alternatives/jre/lib/security/java.security
+
+# Configure the JAVA_OPTIONS, you can add -XshowSettings:vm to also display the heap size.
+ENV JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
+
+COPY target/lib/* /deployments/lib/
+COPY target/*-runner.jar /deployments/app.jar
+
+EXPOSE 8080
+USER 1001
+
+ENTRYPOINT [ "/deployments/run-java.sh" ]

--- a/examples/jms/src/main/java/org/acme/jms/PriceConsumer.java
+++ b/examples/jms/src/main/java/org/acme/jms/PriceConsumer.java
@@ -1,0 +1,83 @@
+package org.acme.jms;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.event.Observes;
+import javax.inject.Inject;
+import javax.jms.ConnectionFactory;
+import javax.jms.JMSConsumer;
+import javax.jms.JMSContext;
+import javax.jms.JMSException;
+import javax.jms.Session;
+
+import io.quarkus.runtime.ShutdownEvent;
+import io.quarkus.runtime.StartupEvent;
+import io.smallrye.asyncapi.spec.annotations.channel.ChannelItem;
+import io.smallrye.asyncapi.spec.annotations.message.Message;
+import io.smallrye.asyncapi.spec.annotations.operation.Operation;
+import io.smallrye.asyncapi.spec.annotations.schema.Schema;
+import io.smallrye.asyncapi.spec.annotations.schema.SchemaType;
+
+/**
+ * A bean consuming prices from the JMS queue.
+ */
+@ApplicationScoped
+public class PriceConsumer implements Runnable {
+
+    @Inject
+    ConnectionFactory connectionFactory;
+
+    private final ExecutorService scheduler = Executors.newSingleThreadExecutor();
+
+    private volatile String lastPrice;
+
+    public String getLastPrice() {
+        return lastPrice;
+    }
+
+    void onStart(@Observes StartupEvent ev) {
+        scheduler.submit(this);
+    }
+
+    void onStop(@Observes ShutdownEvent ev) {
+        scheduler.shutdown();
+    }
+
+    @Override
+    @ChannelItem(
+        channel = "prices",
+        subscribe = @Operation(
+            operationId = "prices",
+            message = @Message(
+                name = "PriceMessage",
+                contentType = "text/plain",
+                summary = "A random price",
+                payload = @Schema(
+                    type = SchemaType.NUMBER,
+                    name = "price",
+                    minimum = "0",
+                    maximum = "100"
+                ),
+                example = {"42.24", "17.6", "87.12"}
+            )
+        )
+    )
+    public void run() {
+        try (JMSContext context = connectionFactory.createContext(Session.AUTO_ACKNOWLEDGE)) {
+            JMSConsumer consumer = context.createConsumer(context.createQueue("prices"));
+            while (true) {
+                javax.jms.Message message = consumer.receive();
+                if (message == null) {
+                    // receive returns `null` if the JMSConsumer is closed
+                    return;
+                }
+                lastPrice = message.getBody(String.class);
+                System.out.println("Got last price: " + lastPrice);
+            }
+        } catch (JMSException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/examples/jms/src/main/java/org/acme/jms/PriceProducer.java
+++ b/examples/jms/src/main/java/org/acme/jms/PriceProducer.java
@@ -1,0 +1,44 @@
+package org.acme.jms;
+
+import java.util.Random;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.event.Observes;
+import javax.inject.Inject;
+import javax.jms.ConnectionFactory;
+import javax.jms.JMSContext;
+import javax.jms.Session;
+
+import io.quarkus.runtime.ShutdownEvent;
+import io.quarkus.runtime.StartupEvent;
+
+/**
+ * A bean producing random prices every 5 seconds and sending them to the prices JMS queue.
+ */
+@ApplicationScoped
+public class PriceProducer implements Runnable {
+
+    @Inject
+    ConnectionFactory connectionFactory;
+
+    private final Random random = new Random();
+    private final ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
+
+    void onStart(@Observes StartupEvent ev) {
+        scheduler.scheduleWithFixedDelay(this, 0L, 5L, TimeUnit.SECONDS);
+    }
+
+    void onStop(@Observes ShutdownEvent ev) {
+        scheduler.shutdown();
+    }
+
+    @Override
+    public void run() {
+        try (JMSContext context = connectionFactory.createContext(Session.AUTO_ACKNOWLEDGE)) {
+            context.createProducer().send(context.createQueue("prices"), Integer.toString(random.nextInt(100)));
+        }
+    }
+}

--- a/examples/jms/src/main/java/org/acme/jms/PriceResource.java
+++ b/examples/jms/src/main/java/org/acme/jms/PriceResource.java
@@ -1,0 +1,53 @@
+package org.acme.jms;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import io.smallrye.asyncapi.spec.annotations.AsyncAPI;
+import io.smallrye.asyncapi.spec.annotations.info.Info;
+import io.smallrye.asyncapi.spec.annotations.info.License;
+import io.smallrye.asyncapi.spec.annotations.server.Server;
+
+/**
+ * A simple resource showing the last price.
+ */
+@AsyncAPI(
+    asyncapi = "2.0.0",
+    defaultContentType = "text/plain",
+    info = @Info(
+        title = "JMS Quickstart API",
+        version = "1.0-SNAPSHOT",
+        description = "In this guide, we are going to generate (random) prices in one component."
+            + " These prices are written in a JMS queue (prices)."
+            + " A second component reads from the JMS prices queue and apply some magic conversion to the price."
+            + " The result is sent to an in-memory stream consumed by a JAX-RS resource."
+            + " The data is sent to a browser using server-sent events.",
+        license = @License(
+            name = "Apache 2.0",
+            url = "https://www.apache.org/licenses/LICENSE-2.0"
+        )
+    ),
+    servers = {
+        @Server(
+            name = "develop",
+            url = "tcp://localhost:61616",
+            protocol = "jms"
+        )
+    }
+)
+@Path("/prices")
+public class PriceResource {
+
+    @Inject
+    PriceConsumer consumer;
+
+    @GET
+    @Path("last")
+    @Produces(MediaType.TEXT_PLAIN)
+    public String last() {
+        return consumer.getLastPrice();
+    }
+}

--- a/examples/jms/src/main/resources/META-INF/resources/prices.html
+++ b/examples/jms/src/main/resources/META-INF/resources/prices.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Prices</title>
+
+    <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/patternfly/3.24.0/css/patternfly.min.css">
+    <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/patternfly/3.24.0/css/patternfly-additions.min.css">
+</head>
+<body>
+<div class="container">
+    <h1><strong>Last price</strong></h1>
+    <div class="row">
+    <h2 class="col-md-12">The last price is <strong><span id="content">N/A</span>&nbsp;&euro;</strong>.</h2>
+    </div>
+</div>
+</body>
+<script src="https://code.jquery.com/jquery-3.3.1.min.js"></script>
+<script>
+    var source = new EventSource("/prices/stream");
+    source.onmessage = function (event) {
+        document.getElementById("content").innerHTML = event.data;
+    };
+</script>
+</html>

--- a/examples/jms/src/main/resources/application.properties
+++ b/examples/jms/src/main/resources/application.properties
@@ -1,0 +1,4 @@
+# Configures the Artemis properties.
+quarkus.artemis.url=tcp://localhost:61616
+quarkus.artemis.username=quarkus
+quarkus.artemis.password=quarkus

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -28,6 +28,10 @@
     </parent>
 
     <artifactId>smallrye-async-api-examples</artifactId>
-    <name>SmallRye: AsyncAPI Examples</name>
     <packaging>pom</packaging>
+    <name>SmallRye: MicroProfile AsyncAPI Examples</name>
+
+    <modules>
+        <module>jms</module>
+    </modules>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -123,11 +123,11 @@
         <module>spec</module>
         <module>core</module>
         <module>tck</module>
-        <module>tools</module>
-        <module>examples</module>
         <module>ui</module>
+        <module>tools</module>
         <module>implementation</module>
         <module>extension-reactive-messaging</module>
+        <module>examples</module>
     </modules>
 
     <dependencyManagement>


### PR DESCRIPTION
```yaml
---
asyncapi: "2.0.0"
defaultContentType: "text/plain"
info:
  title: "JMS Quickstart API"
  description: "In this guide, we are going to generate (random) prices in one component.\
    \ These prices are written in a JMS queue (prices). A second component reads from\
    \ the JMS prices queue and apply some magic conversion to the price. The result\
    \ is sent to an in-memory stream consumed by a JAX-RS resource. The data is sent\
    \ to a browser using server-sent events."
  license:
    name: "Apache 2.0"
    url: "https://www.apache.org/licenses/LICENSE-2.0"
  version: "1.0-SNAPSHOT"
servers:
  develop:
    url: "tcp://localhost:61616"
    protocol: "jms"
channels:
  prices:
    subscribe:
      operationId: "prices"
      message:
        payload:
          maximum: 100
          minimum: 0
          type: "number"
        contentType: "text/plain"
        name: "PriceMessage"
        summary: "A random price"
```