### PR TITLE
Add AMQP (quarkus-prices) example

### DIFF
--- a/examples/amqp/README.md
+++ b/examples/amqp/README.md
@@ -1,0 +1,32 @@
+Quarkus AMQP 1.0 Quickstart
+============================
+
+This project illustrates how you can interact with AMQP 1.0 (Apache Artemis in this quickstart) using MicroProfile Reactive Messaging.
+
+## AMQP Broker
+
+First you need an AMQP broker. You can follow the instructions from the [Apache Artemis web site](https://activemq.apache.org/components/artemis/) or run `docker-compose up` if you have docker installed on your machine.
+
+## Start the application
+
+The application can be started using: 
+
+```bash
+mvn quarkus:dev
+```  
+
+Then, open your browser to `http://localhost:8080/prices.html`, and you should see a fluctuating price.
+
+## Anatomy
+
+In addition to the `prices.html` page, the application is composed by 3 components:
+
+* `PriceGenerator` - a bean generating random price. They are sent to a AMQP queue.
+* `PriceConverter` - on the consuming side, the `PriceConverter` receives the AMQP message and convert the price.
+The result is sent to an in-memory stream of data
+* `PriceResource`  - the `PriceResource` retrieves the in-memory stream of data in which the converted prices are sent and send these prices to the browser using Server-Sent Events.
+
+The interaction with AMQP is managed by MicroProfile Reactive Messaging.
+The configuration is located in the application configuration.
+
+NOTE: Hey, it's the same code as the Kafka quickstart! Yes, it is, the only difference is the _connector_ configured in the `application.properties`.

--- a/examples/amqp/docker-compose.yaml
+++ b/examples/amqp/docker-compose.yaml
@@ -1,0 +1,13 @@
+version: '2'
+
+services:
+
+  artemis:
+    image: vromero/activemq-artemis:2.9.0-alpine
+    ports:
+      - "8161:8161"
+      - "61616:61616"
+      - "5672:5672"
+    environment:
+      ARTEMIS_USERNAME: quarkus
+      ARTEMIS_PASSWORD: quarkus

--- a/examples/amqp/pom.xml
+++ b/examples/amqp/pom.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>io.smallrye</groupId>
+    <artifactId>smallrye-async-api-examples-amqp</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <name>SmallRye: AsyncAPI Examples - AMQP</name>
+
+    <properties>
+        <version.quarkus>1.12.0.Final</version.quarkus>
+        <version.asyncapi>1.0.0-SNAPSHOT</version.asyncapi>
+
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>1.8</maven.compiler.source>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-universe-bom</artifactId>
+                <version>${version.quarkus}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-smallrye-reactive-messaging-amqp</artifactId>
+        </dependency>
+
+        <!-- AsyncAPI -->
+        <dependency>
+            <groupId>io.smallrye</groupId>
+            <artifactId>smallrye-async-api-spec-api</artifactId>
+            <version>${version.asyncapi}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.smallrye</groupId>
+            <artifactId>smallrye-async-api-quarkus-extension</artifactId>
+            <version>${version.asyncapi}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-maven-plugin</artifactId>
+                <version>${version.quarkus}</version>
+                <configuration>
+                    <uberJar>true</uberJar>
+                    <ignoredEntries>
+                        <ignoredEntry>META-INF/DEPENDENCIES.txt</ignoredEntry>
+                    </ignoredEntries>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>build</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/examples/amqp/src/main/docker/Dockerfile.jvm
+++ b/examples/amqp/src/main/docker/Dockerfile.jvm
@@ -1,0 +1,31 @@
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.1
+
+ARG JAVA_PACKAGE=java-1.8.0-openjdk-headless
+ARG RUN_JAVA_VERSION=1.3.5
+
+ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
+
+# Install java and the run-java script
+# Also set up permissions for user `1001`
+RUN microdnf install openssl curl ca-certificates ${JAVA_PACKAGE} \
+    && microdnf update \
+    && microdnf clean all \
+    && mkdir /deployments \
+    && chown 1001 /deployments \
+    && chmod "g+rwX" /deployments \
+    && chown 1001:root /deployments \
+    && curl https://repo1.maven.org/maven2/io/fabric8/run-java-sh/${RUN_JAVA_VERSION}/run-java-sh-${RUN_JAVA_VERSION}-sh.sh -o /deployments/run-java.sh \
+    && chown 1001 /deployments/run-java.sh \
+    && chmod 540 /deployments/run-java.sh \
+    && echo "securerandom.source=file:/dev/urandom" >> /etc/alternatives/jre/lib/security/java.security
+
+# Configure the JAVA_OPTIONS, you can add -XshowSettings:vm to also display the heap size.
+ENV JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
+
+COPY target/lib/* /deployments/lib/
+COPY target/*-runner.jar /deployments/app.jar
+
+EXPOSE 8080
+USER 1001
+
+ENTRYPOINT [ "/deployments/run-java.sh" ]

--- a/examples/amqp/src/main/docker/Dockerfile.legacy-jar
+++ b/examples/amqp/src/main/docker/Dockerfile.legacy-jar
@@ -1,0 +1,51 @@
+####
+# This Dockerfile is used in order to build a container that runs the Quarkus application in JVM mode
+#
+# Before building the container image run:
+#
+# ./mvnw package -Dquarkus.package.type=legacy-jar
+#
+# Then, build the image with:
+#
+# docker build -f src/main/docker/Dockerfile.legacy-jar -t quarkus/amqp-legacy-jar .
+#
+# Then run the container using:
+#
+# docker run -i --rm -p 8080:8080 quarkus/amqp-legacy-jar
+#
+# If you want to include the debug port into your docker image
+# you will have to expose the debug port (default 5005) like this :  EXPOSE 8080 5050
+#
+# Then run the container using :
+#
+# docker run -i --rm -p 8080:8080 -p 5005:5005 -e JAVA_ENABLE_DEBUG="true" quarkus/amqp-legacy-jar
+#
+###
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
+
+ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG RUN_JAVA_VERSION=1.3.8
+ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
+# Install java and the run-java script
+# Also set up permissions for user `1001`
+RUN microdnf install curl ca-certificates ${JAVA_PACKAGE} \
+    && microdnf update \
+    && microdnf clean all \
+    && mkdir /deployments \
+    && chown 1001 /deployments \
+    && chmod "g+rwX" /deployments \
+    && chown 1001:root /deployments \
+    && curl https://repo1.maven.org/maven2/io/fabric8/run-java-sh/${RUN_JAVA_VERSION}/run-java-sh-${RUN_JAVA_VERSION}-sh.sh -o /deployments/run-java.sh \
+    && chown 1001 /deployments/run-java.sh \
+    && chmod 540 /deployments/run-java.sh \
+    && echo "securerandom.source=file:/dev/urandom" >> /etc/alternatives/jre/lib/security/java.security
+
+# Configure the JAVA_OPTIONS, you can add -XshowSettings:vm to also display the heap size.
+ENV JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
+COPY target/lib/* /deployments/lib/
+COPY target/*-runner.jar /deployments/app.jar
+
+EXPOSE 8080
+USER 1001
+
+ENTRYPOINT [ "/deployments/run-java.sh" ]

--- a/examples/amqp/src/main/docker/Dockerfile.native
+++ b/examples/amqp/src/main/docker/Dockerfile.native
@@ -1,0 +1,27 @@
+####
+# This Dockerfile is used in order to build a container that runs the Quarkus application in native (no JVM) mode
+#
+# Before building the container image run:
+#
+# ./mvnw package -Pnative
+#
+# Then, build the image with:
+#
+# docker build -f src/main/docker/Dockerfile.native -t quarkus/amqp .
+#
+# Then run the container using:
+#
+# docker run -i --rm -p 8080:8080 quarkus/amqp
+#
+###
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3
+WORKDIR /work/
+RUN chown 1001 /work \
+    && chmod "g+rwX" /work \
+    && chown 1001:root /work
+COPY --chown=1001:root target/*-runner /work/application
+
+EXPOSE 8080
+USER 1001
+
+CMD ["./application", "-Dquarkus.http.host=0.0.0.0"]

--- a/examples/amqp/src/main/docker/Dockerfile.native-distroless
+++ b/examples/amqp/src/main/docker/Dockerfile.native-distroless
@@ -1,0 +1,23 @@
+####
+# This Dockerfile is used in order to build a distroless container that runs the Quarkus application in native (no JVM) mode
+#
+# Before building the container image run:
+#
+# ./mvnw package -Pnative
+#
+# Then, build the image with:
+#
+# docker build -f src/main/docker/Dockerfile.native-distroless -t quarkus/amqp .
+#
+# Then run the container using:
+#
+# docker run -i --rm -p 8080:8080 quarkus/amqp
+#
+###
+FROM quay.io/quarkus/quarkus-distroless-image:1.0
+COPY target/*-runner /application
+
+EXPOSE 8080
+USER nonroot
+
+CMD ["./application", "-Dquarkus.http.host=0.0.0.0"]

--- a/examples/amqp/src/main/java/org/acme/amqp/PriceConverter.java
+++ b/examples/amqp/src/main/java/org/acme/amqp/PriceConverter.java
@@ -1,0 +1,34 @@
+package org.acme.amqp;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.reactive.messaging.Acknowledgment;
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+import org.eclipse.microprofile.reactive.messaging.Outgoing;
+
+import io.smallrye.asyncapi.spec.annotations.channel.ChannelItem;
+import io.smallrye.asyncapi.spec.annotations.message.Message;
+import io.smallrye.asyncapi.spec.annotations.operation.Operation;
+import io.smallrye.asyncapi.spec.annotations.schema.Schema;
+import io.smallrye.asyncapi.spec.annotations.schema.SchemaType;
+import io.smallrye.reactive.messaging.annotations.Broadcast;
+
+/**
+ * A bean consuming data from the "prices" AMQP queue and applying some conversion.
+ * The result is pushed to the "my-data-stream" stream which is an in-memory stream.
+ */
+@ApplicationScoped
+public class PriceConverter {
+
+    private static final double CONVERSION_RATE = 0.88;
+
+    @ChannelItem(channel = "prices", subscribe = @Operation(operationId = "prices", message = @Message(contentType = "text/plain", summary = "A random price", payload = @Schema(type = SchemaType.NUMBER, name = "price", minimum = "0", maximum = "100"), example = {
+            "42.24", "17.6", "87.12" })))
+    @Incoming("prices")
+    @Outgoing("my-data-stream")
+    @Broadcast
+    @Acknowledgment(Acknowledgment.Strategy.PRE_PROCESSING)
+    public double process(int priceInUsd) {
+        return priceInUsd * CONVERSION_RATE;
+    }
+}

--- a/examples/amqp/src/main/java/org/acme/amqp/PriceGenerator.java
+++ b/examples/amqp/src/main/java/org/acme/amqp/PriceGenerator.java
@@ -1,0 +1,27 @@
+package org.acme.amqp;
+
+import java.time.Duration;
+import java.util.Random;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.reactive.messaging.Outgoing;
+
+import io.smallrye.mutiny.Multi;
+
+/**
+ * A bean producing random prices every 5 seconds.
+ * The prices are written to a AMQP queue (prices). The AMQP configuration is specified in the application configuration.
+ */
+@ApplicationScoped
+public class PriceGenerator {
+
+    private Random random = new Random();
+
+    @Outgoing("generated-price")
+    public Multi<Integer> generate() {
+        return Multi.createFrom().ticks().every(Duration.ofSeconds(5))
+                .onOverflow().drop()
+                .map(tick -> random.nextInt(100));
+    }
+}

--- a/examples/amqp/src/main/java/org/acme/amqp/PriceResource.java
+++ b/examples/amqp/src/main/java/org/acme/amqp/PriceResource.java
@@ -1,0 +1,37 @@
+package org.acme.amqp;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import org.eclipse.microprofile.reactive.messaging.Channel;
+import org.reactivestreams.Publisher;
+
+import io.smallrye.asyncapi.spec.annotations.AsyncAPI;
+import io.smallrye.asyncapi.spec.annotations.info.Info;
+import io.smallrye.asyncapi.spec.annotations.info.License;
+
+/**
+ * A simple resource retrieving the "in-memory" "my-data-stream" and sending the items to a server sent event.
+ */
+@AsyncAPI(asyncapi = "2.0.0", defaultContentType = "text/plain", info = @Info(title = "AMQP Quickstart API", version = "1.0-SNAPSHOT", description = "In this guide, we are going to generate (random) prices in one component."
+        + " These prices are written in a AMQP queue (prices)."
+        + " A second component reads from the AMQP prices queue and apply some magic conversion to the price."
+        + " The result is sent to an in-memory stream consumed by a JAX-RS resource."
+        + " The data is sent to a browser using server-sent events.", license = @License(name = "Apache 2.0", url = "https://www.apache.org/licenses/LICENSE-2.0")))
+@Path("/prices")
+public class PriceResource {
+
+    @Inject
+    @Channel("my-data-stream")
+    Publisher<Double> prices;
+
+    @GET
+    @Path("/stream")
+    @Produces(MediaType.SERVER_SENT_EVENTS)
+    public Publisher<Double> stream() {
+        return prices;
+    }
+}

--- a/examples/amqp/src/main/resources/META-INF/resources/index.html
+++ b/examples/amqp/src/main/resources/META-INF/resources/index.html
@@ -1,0 +1,152 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>AMQP Quickstart - 1.0.0-SNAPSHOT</title>
+    <style>
+        h1, h2, h3, h4, h5, h6 {
+            margin-bottom: 0.5rem;
+            font-weight: 400;
+            line-height: 1.5;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+        }
+
+        h2 {
+            font-size: 2rem
+        }
+
+        h3 {
+            font-size: 1.75rem
+        }
+
+        h4 {
+            font-size: 1.5rem
+        }
+
+        h5 {
+            font-size: 1.25rem
+        }
+
+        h6 {
+            font-size: 1rem
+        }
+
+        .lead {
+            font-weight: 300;
+            font-size: 2rem;
+        }
+
+        .banner {
+            font-size: 2.7rem;
+            margin: 0;
+            padding: 2rem 1rem;
+            background-color: #00A1E2;
+            color: white;
+        }
+
+        body {
+            margin: 0;
+            font-family: -apple-system, system-ui, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+        }
+
+        code {
+            font-family: SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+            font-size: 87.5%;
+            color: #e83e8c;
+            word-break: break-word;
+        }
+
+        .left-column {
+            padding: .75rem;
+            max-width: 75%;
+            min-width: 55%;
+        }
+
+        .right-column {
+            padding: .75rem;
+            max-width: 25%;
+        }
+
+        .container {
+            display: flex;
+            width: 100%;
+        }
+
+        li {
+            margin: 0.75rem;
+        }
+
+        .right-section {
+            margin-left: 1rem;
+            padding-left: 0.5rem;
+        }
+
+        .right-section h3 {
+            padding-top: 0;
+            font-weight: 200;
+        }
+
+        .right-section ul {
+            border-left: 0.3rem solid #00A1E2;
+            list-style-type: none;
+            padding-left: 0;
+        }
+
+    </style>
+</head>
+<body>
+
+<div class="banner lead">
+    Your new Cloud-Native application is ready!
+</div>
+
+<div class="container">
+    <div class="left-column">
+        <p class="lead"> Congratulations, you have created a new Quarkus application.</p>
+
+        <h2>Why do you see this?</h2>
+
+        <p>This page is served by Quarkus. The source is in
+            <code>src/main/resources/META-INF/resources/index.html</code>.</p>
+
+        <h2>What can I do from here?</h2>
+
+        <p>If not already done, run the application in <em>dev mode</em> using: <code>mvn quarkus:dev</code>.
+        </p>
+        <ul>
+            <li>Add REST resources, Servlets, functions and other services in <code>src/main/java</code>.</li>
+            <li>Your static assets are located in <code>src/main/resources/META-INF/resources</code>.</li>
+            <li>Configure your application in <code>src/main/resources/application.properties</code>.
+            </li>
+        </ul>
+
+        <h2>How do I get rid of this page?</h2>
+        <p>Just delete the <code>src/main/resources/META-INF/resources/index.html</code> file.</p>
+    </div>
+    <div class="right-column">
+        <div class="right-section">
+            <h3>Application</h3>
+            <ul>
+                <li>GroupId: org.acme.quarkus.sample</li>
+                <li>ArtifactId: amqp-quickstart</li>
+                <li>Version: 1.0.0-SNAPSHOT</li>
+                <li>Quarkus Version: 1.12.1.Final</li>
+            </ul>
+        </div>
+        <div class="right-section">
+            <h3>Next steps</h3>
+            <ul>
+                <li><a href="https://quarkus.io/guides/maven-tooling.html">Setup your IDE</a></li>
+                <li><a href="https://quarkus.io/guides/getting-started.html">Getting started</a></li>
+                <li><a href="https://quarkus.io">Quarkus Web Site</a></li>
+            </ul>
+        </div>
+    </div>
+</div>
+
+
+</body>
+</html>

--- a/examples/amqp/src/main/resources/META-INF/resources/prices.html
+++ b/examples/amqp/src/main/resources/META-INF/resources/prices.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Prices</title>
+
+    <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/patternfly/3.24.0/css/patternfly.min.css">
+    <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/patternfly/3.24.0/css/patternfly-additions.min.css">
+</head>
+<body>
+<div class="container">
+    <h1><strong>Last price</strong></h1>
+    <div class="row">
+    <h2 class="col-md-12">The last price is <strong><span id="content">N/A</span>&nbsp;&euro;</strong>.</h2>
+    </div>
+</div>
+</body>
+<script src="https://code.jquery.com/jquery-3.3.1.min.js"></script>
+<script>
+    var source = new EventSource("/prices/stream");
+    source.onmessage = function (event) {
+        document.getElementById("content").innerHTML = event.data;
+    };
+</script>
+</html>

--- a/examples/amqp/src/main/resources/application.properties
+++ b/examples/amqp/src/main/resources/application.properties
@@ -1,0 +1,11 @@
+# Configures the AMQP broker credentials.
+amqp-username=quarkus
+amqp-password=quarkus
+
+# Configure the AMQP connector to write to the `prices`  address
+mp.messaging.outgoing.generated-price.connector=smallrye-amqp
+mp.messaging.outgoing.generated-price.address=prices
+
+# Configure the AMQP connector to read from the `prices` queue
+mp.messaging.incoming.prices.connector=smallrye-amqp
+mp.messaging.incoming.prices.durable=true

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -29,9 +29,5 @@
 
     <artifactId>smallrye-async-api-examples</artifactId>
     <packaging>pom</packaging>
-    <name>SmallRye: MicroProfile AsyncAPI Examples</name>
-
-    <modules>
-        <module>jms</module>
-    </modules>
+    <name>SmallRye: AsyncAPI Examples</name>
 </project>


### PR DESCRIPTION
```yaml
---
asyncapi: "2.0.0"
defaultContentType: "text/plain"
info:
  title: "AMQP Quickstart API"
  description: "In this guide, we are going to generate (random) prices in one component.\
    \ These prices are written in a AMQP queue (prices). A second component reads\
    \ from the AMQP prices queue and apply some magic conversion to the price. The\
    \ result is sent to an in-memory stream consumed by a JAX-RS resource. The data\
    \ is sent to a browser using server-sent events."
  license:
    name: "Apache 2.0"
    url: "https://www.apache.org/licenses/LICENSE-2.0"
  version: "1.0-SNAPSHOT"
servers:
  dev:
    url: "localhost:8161"
    protocol: "amqp"
channels:
  prices:
    subscribe:
      operationId: "prices"
      message:
        payload:
          maximum: 100
          minimum: 0
          type: "number"
        contentType: "text/plain"
        summary: "A random price"
```