### PR TITLE
Add kafka (quarkus-prices) example

### DIFF
--- a/examples/kafka/.dockerignore
+++ b/examples/kafka/.dockerignore
@@ -1,0 +1,4 @@
+*
+!target/*-runner
+!target/*-runner.jar
+!target/lib/*

--- a/examples/kafka/README.md
+++ b/examples/kafka/README.md
@@ -1,0 +1,30 @@
+Quarkus Kafka Quickstart
+========================
+
+This project illustrates how you can interact with Apache Kafka using MicroProfile Reactive Messaging.
+
+## Kafka cluster
+
+First you need a Kafka cluster. You can follow the instructions from the [Apache Kafka web site](https://kafka.apache.org/quickstart) or run `docker-compose up` if you have docker installed on your machine.
+
+## Start the application
+
+The application can be started using: 
+
+```bash
+mvn quarkus:dev
+```
+
+Then, open your browser to `http://localhost:8080/prices.html`, and you should see a fluctuating price.
+
+## Anatomy
+
+In addition to the `prices.html` page, the application is composed by 3 components:
+
+* `PriceGenerator` - a bean generating random price. They are sent to a Kafka topic
+* `PriceConverter` - on the consuming side, the `PriceConverter` receives the Kafka message and convert the price.
+The result is sent to an in-memory stream of data
+* `PriceResource`  - the `PriceResource` retrieves the in-memory stream of data in which the converted prices are sent and send these prices to the browser using Server-Sent Events.
+
+The interaction with Kafka is managed by MicroProfile Reactive Messaging.
+The configuration is located in the application configuration.

--- a/examples/kafka/docker-compose.yaml
+++ b/examples/kafka/docker-compose.yaml
@@ -1,0 +1,31 @@
+version: '2'
+
+services:
+
+  zookeeper:
+    image: strimzi/kafka:0.19.0-kafka-2.5.0
+    command: [
+        "sh", "-c",
+        "bin/zookeeper-server-start.sh config/zookeeper.properties"
+    ]
+    ports:
+      - "2181:2181"
+    environment:
+      LOG_DIR: /tmp/logs
+
+  kafka:
+    image: strimzi/kafka:0.19.0-kafka-2.5.0
+    command: [
+        "sh", "-c",
+        "bin/kafka-server-start.sh config/server.properties --override listeners=$${KAFKA_LISTENERS} --override advertised.listeners=$${KAFKA_ADVERTISED_LISTENERS} --override zookeeper.connect=$${KAFKA_ZOOKEEPER_CONNECT}"
+    ]
+    depends_on:
+      - zookeeper
+    ports:
+      - "9092:9092"
+    environment:
+      LOG_DIR: "/tmp/logs"
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092
+      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+

--- a/examples/kafka/pom.xml
+++ b/examples/kafka/pom.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <modelVersion>4.0.0</modelVersion>
+
+
+    <groupId>io.smallrye</groupId>
+    <artifactId>smallrye-async-api-examples-kafka</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+
+    <name>SmallRye: MicroProfile AsyncAPI Examples Kafka</name>
+
+    <properties>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>1.8</maven.compiler.source>
+
+        <version.quarkus>1.12.0.Final</version.quarkus>
+        <version.asyncapi>1.0.0-SNAPSHOT</version.asyncapi>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-universe-bom</artifactId>
+                <version>${version.quarkus}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-smallrye-reactive-messaging-kafka</artifactId>
+        </dependency>
+
+        <!-- AsyncAPI -->
+        <dependency>
+            <groupId>io.smallrye</groupId>
+            <artifactId>smallrye-async-api-spec-api</artifactId>
+            <version>${version.asyncapi}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.smallrye</groupId>
+            <artifactId>smallrye-async-api-quarkus-extension</artifactId>
+            <version>${version.asyncapi}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-maven-plugin</artifactId>
+                <version>${version.quarkus}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>build</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/examples/kafka/src/main/docker/Dockerfile.jvm
+++ b/examples/kafka/src/main/docker/Dockerfile.jvm
@@ -1,0 +1,31 @@
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.1
+
+ARG JAVA_PACKAGE=java-1.8.0-openjdk-headless
+ARG RUN_JAVA_VERSION=1.3.5
+
+ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
+
+# Install java and the run-java script
+# Also set up permissions for user `1001`
+RUN microdnf install openssl curl ca-certificates ${JAVA_PACKAGE} \
+    && microdnf update \
+    && microdnf clean all \
+    && mkdir /deployments \
+    && chown 1001 /deployments \
+    && chmod "g+rwX" /deployments \
+    && chown 1001:root /deployments \
+    && curl https://repo1.maven.org/maven2/io/fabric8/run-java-sh/${RUN_JAVA_VERSION}/run-java-sh-${RUN_JAVA_VERSION}-sh.sh -o /deployments/run-java.sh \
+    && chown 1001 /deployments/run-java.sh \
+    && chmod 540 /deployments/run-java.sh \
+    && echo "securerandom.source=file:/dev/urandom" >> /etc/alternatives/jre/lib/security/java.security
+
+# Configure the JAVA_OPTIONS, you can add -XshowSettings:vm to also display the heap size.
+ENV JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
+
+COPY target/lib/* /deployments/lib/
+COPY target/*-runner.jar /deployments/app.jar
+
+EXPOSE 8080
+USER 1001
+
+ENTRYPOINT [ "/deployments/run-java.sh" ]

--- a/examples/kafka/src/main/java/org/acme/kafka/PriceConverter.java
+++ b/examples/kafka/src/main/java/org/acme/kafka/PriceConverter.java
@@ -1,0 +1,32 @@
+package org.acme.kafka;
+
+import io.smallrye.asyncapi.spec.annotations.channel.ChannelItem;
+import io.smallrye.asyncapi.spec.annotations.message.Message;
+import io.smallrye.asyncapi.spec.annotations.operation.Operation;
+import io.smallrye.asyncapi.spec.annotations.schema.Schema;
+import io.smallrye.asyncapi.spec.annotations.schema.SchemaType;
+import org.eclipse.microprofile.reactive.messaging.Acknowledgment;
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+import org.eclipse.microprofile.reactive.messaging.Outgoing;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import io.smallrye.reactive.messaging.annotations.Broadcast;
+
+/**
+ * A bean consuming data from the "prices" Kafka topic and applying some conversion.
+ * The result is pushed to the "my-data-stream" stream which is an in-memory stream.
+ */
+@ApplicationScoped
+public class PriceConverter {
+
+    private static final double CONVERSION_RATE = 0.88;
+
+    @Incoming("prices")
+    @Outgoing("my-data-stream")
+    @Broadcast
+    @Acknowledgment(Acknowledgment.Strategy.PRE_PROCESSING)
+    public double process(int priceInUsd) {
+        return priceInUsd * CONVERSION_RATE;
+    }
+}

--- a/examples/kafka/src/main/java/org/acme/kafka/PriceGenerator.java
+++ b/examples/kafka/src/main/java/org/acme/kafka/PriceGenerator.java
@@ -1,0 +1,49 @@
+package org.acme.kafka;
+
+import java.time.Duration;
+import java.util.Random;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.reactive.messaging.Outgoing;
+
+import io.smallrye.asyncapi.spec.annotations.channel.ChannelItem;
+import io.smallrye.asyncapi.spec.annotations.message.Message;
+import io.smallrye.asyncapi.spec.annotations.operation.Operation;
+import io.smallrye.asyncapi.spec.annotations.schema.Schema;
+import io.smallrye.asyncapi.spec.annotations.schema.SchemaType;
+import io.smallrye.mutiny.Multi;
+
+/**
+ * A bean producing random prices every 5 seconds.
+ * The prices are written to a Kafka topic (prices). The Kafka configuration is specified in the application configuration.
+ */
+@ApplicationScoped
+public class PriceGenerator {
+
+    private Random random = new Random();
+
+    @ChannelItem(
+        channel = "prices",
+        publish = @Operation(
+            operationId = "generated-price",
+            message = @Message(
+                contentType = "text/plain",
+                summary = "A random price",
+                payload = @Schema(
+                    type = SchemaType.NUMBER,
+                    name = "price",
+                    minimum = "0",
+                    maximum = "100"
+                ),
+                example = {"42.24", "17.6", "87.12"}
+            )
+        )
+    )
+    @Outgoing("generated-price")
+    public Multi<Integer> generate() {
+        return Multi.createFrom().ticks().every(Duration.ofSeconds(5))
+                .onOverflow().drop()
+                .map(tick -> random.nextInt(100));
+    }
+}

--- a/examples/kafka/src/main/java/org/acme/kafka/PriceResource.java
+++ b/examples/kafka/src/main/java/org/acme/kafka/PriceResource.java
@@ -1,0 +1,57 @@
+package org.acme.kafka;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import io.smallrye.asyncapi.spec.annotations.server.Server;
+import org.eclipse.microprofile.reactive.messaging.Channel;
+import org.reactivestreams.Publisher;
+
+import io.smallrye.asyncapi.spec.annotations.AsyncAPI;
+import io.smallrye.asyncapi.spec.annotations.info.Info;
+import io.smallrye.asyncapi.spec.annotations.info.License;
+
+/**
+ * A simple resource retrieving the "in-memory" "my-data-stream" and sending the items to a server sent event.
+ */
+@AsyncAPI(
+    asyncapi = "2.0.0",
+    defaultContentType = "text/plain",
+    info = @Info(
+        title = "Kafka Quickstart API",
+        version = "1.0-SNAPSHOT",
+        description = "In this guide, we are going to generate (random) prices in one component."
+            + " These prices are written in a Kafka topic (prices)."
+            + " A second component reads from the prices Kafka topic and apply some magic conversion to the price."
+            + " The result is sent to an in-memory stream consumed by a JAX-RS resource."
+            + " The data is sent to a browser using server-sent events.",
+        license = @License(
+            name = "Apache 2.0",
+            url = "https://www.apache.org/licenses/LICENSE-2.0"
+        )
+    ),
+    servers = {
+        @Server(
+            name = "develop",
+            url = "tcp://localhost:9092",
+            protocol = "kafka"
+        )
+    }
+)
+@Path("/prices")
+public class PriceResource {
+
+    @Inject
+    @Channel("my-data-stream")
+    Publisher<Double> prices;
+
+    @GET
+    @Path("/stream")
+    @Produces(MediaType.SERVER_SENT_EVENTS)
+    public Publisher<Double> stream() {
+        return prices;
+    }
+}

--- a/examples/kafka/src/main/resources/META-INF/resources/prices.html
+++ b/examples/kafka/src/main/resources/META-INF/resources/prices.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Prices</title>
+
+    <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/patternfly/3.24.0/css/patternfly.min.css">
+    <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/patternfly/3.24.0/css/patternfly-additions.min.css">
+</head>
+<body>
+<div class="container">
+    <h1><strong>Last price</strong></h1>
+    <div class="row">
+    <h2 class="col-md-12">The last price is <strong><span id="content">N/A</span>&nbsp;&euro;</strong>.</h2>
+    </div>
+</div>
+</body>
+<script src="https://code.jquery.com/jquery-3.3.1.min.js"></script>
+<script>
+    var source = new EventSource("/prices/stream");
+    source.onmessage = function (event) {
+        document.getElementById("content").innerHTML = event.data;
+    };
+</script>
+</html>

--- a/examples/kafka/src/main/resources/application.properties
+++ b/examples/kafka/src/main/resources/application.properties
@@ -1,0 +1,9 @@
+# Configure the Kafka sink (we write to it)
+mp.messaging.outgoing.generated-price.connector=smallrye-kafka
+mp.messaging.outgoing.generated-price.topic=prices
+mp.messaging.outgoing.generated-price.value.serializer=org.apache.kafka.common.serialization.IntegerSerializer
+
+# Configure the Kafka source (we read from it)
+mp.messaging.incoming.prices.connector=smallrye-kafka
+mp.messaging.incoming.prices.topic=prices
+mp.messaging.incoming.prices.value.deserializer=org.apache.kafka.common.serialization.IntegerDeserializer

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (C) open knowledge GmbH
+  ~ Copyright (C) 2020 open knowledge
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/pom.xml
+++ b/pom.xml
@@ -192,7 +192,7 @@
                 <version>${version.jakarta.servlet}</version>
             </dependency>
 
-            <!-- Relative Messaging -->
+            <!-- Reactive Messaging -->
             <dependency>
                 <groupId>io.smallrye.reactive</groupId>
                 <artifactId>smallrye-reactive-messaging-api</artifactId>


### PR DESCRIPTION
```yaml
---
asyncapi: "2.0.0"
defaultContentType: "text/plain"
info:
  title: "Kafka Quickstart API"
  description: "In this guide, we are going to generate (random) prices in one component.\
    \ These prices are written in a Kafka topic (prices). A second component reads\
    \ from the prices Kafka topic and apply some magic conversion to the price. The\
    \ result is sent to an in-memory stream consumed by a JAX-RS resource. The data\
    \ is sent to a browser using server-sent events."
  license:
    name: "Apache 2.0"
    url: "https://www.apache.org/licenses/LICENSE-2.0"
  version: "1.0-SNAPSHOT"
servers:
  develop:
    url: "tcp://localhost:9092"
    protocol: "kafka"
channels:
  prices:
    publish:
      operationId: "generated-price"
      message:
        payload:
          maximum: 100
          minimum: 0
          type: "number"
        contentType: "text/plain"
        summary: "A random price"
```